### PR TITLE
Add social media links with target to open in new tab

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -57,10 +57,15 @@
           <section class="footer-social">
             <h4>Connect with us</h4>
             <ul>
-              <li class="social-icon -twitter"><a href="https://twitter.com/nixos_org">Twitter</a></li>
-              <li class="social-icon -youtube"><a
-                  href="https://www.youtube.com/channel/UC3vIimi9q4AT8EgxYp_dWIw">Youtube</a></li>
-              <li class="social-icon -github"><a href="https://github.com/NixOS">GitHub</a></li>
+              <li class="social-icon -twitter">
+  <a href="https://twitter.com/nixos_org" target="_blank" rel="noopener noreferrer">Twitter</a>
+</li>
+<li class="social-icon -youtube">
+  <a href="https://www.youtube.com/channel/UC3vIimi9q4AT8EgxYp_dWIw" target="_blank" rel="noopener noreferrer">YouTube</a>
+</li>
+<li class="social-icon -github">
+  <a href="https://github.com/NixOS" target="_blank" rel="noopener noreferrer">GitHub</a>
+</li>
             </ul>
           </section>
         </div>


### PR DESCRIPTION
Description:
This pull request updates the social media links in the footer section of the website to ensure that they open in a new tab when clicked. Specifically, the following changes were made:

Twitter Link: Added target="_blank" and rel="noopener noreferrer" to ensure the link opens in a new tab securely.
YouTube Link: Applied the same target="_blank" and rel="noopener noreferrer" attributes for secure opening in a new tab.
GitHub Link: Updated with target="_blank" and rel="noopener noreferrer" for consistency and security.
These changes enhance user experience by allowing users to access external social media sites without navigating away from the current website.

Testing:

Verified that all links open in a new tab.
Ensured that rel="noopener noreferrer" is included for security purposes.
Additional Notes:

This update only affects the front-end and does not require any back-end changes.
Please review the changes to ensure they align with the project's style and standards.
